### PR TITLE
Added USER root explicitly

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,5 +1,5 @@
 FROM gitpod/workspace-full-vnc
-
+USER root
 RUN apt-get update \
     && apt-get install -y openjfx libopenjfx-java matchbox \
     && apt-get clean && rm -rf /var/cache/apt/* && rm -rf /var/lib/apt/lists/* && rm -rf /tmp/*


### PR DESCRIPTION
Some of the new workspaces require the user to be mentioned explicitly, otherwise the prebuild fails.